### PR TITLE
YAML設定のspecをtreeに統一

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "moli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moli"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ moli_install
 - name: my-app
   root: true
   lang: typescript
-  spec:
+  tree:
     - name: src
       tree:
         - name: components
@@ -74,8 +74,7 @@ moli_install
 - **`name`**: プロジェクト名
 - **`root`**: ルートプロジェクトかどうか（`true`の場合、現在のディレクトリに直接生成）
 - **`lang`**: 対象プログラミング言語 (`rust`, `go`, `python`, `typescript`, `javascript`)
-- **`spec`**: プロジェクトのトップレベル構造
-- **`tree`**: サブモジュールやネストした構造（再帰的に使用）
+- **`tree`**: ディレクトリ構造を定義（再帰的に使用可能）
 - **`file`**: 生成する個別ファイル（拡張子があれば保持、なければ言語に応じて付与）
 
 ### マルチプロジェクト構成
@@ -85,7 +84,7 @@ moli_install
 ```yaml
 - name: frontend
   lang: typescript
-  spec:
+  tree:
     - name: src
       tree:
         - name: components
@@ -94,7 +93,7 @@ moli_install
 
 - name: backend  
   lang: rust
-  spec:
+  tree:
     - name: src
       file:
         - name: main
@@ -124,7 +123,7 @@ moli_install
 - name: my-rust-app
   root: true
   lang: rust
-  spec:
+  tree:
     - name: src
       file:
         - name: main
@@ -144,7 +143,7 @@ moli_install
 - name: my-web-app
   root: true
   lang: typescript
-  spec:
+  tree:
     - name: src
       tree:
         - name: components
@@ -161,7 +160,7 @@ moli_install
 - name: my-go-app
   root: true
   lang: go
-  spec:
+  tree:
     - name: pkg
       tree:
         - name: models
@@ -209,7 +208,7 @@ moliは3層のファイル保護システムを実装しています:
 現在のバージョン: **v1.0.0**
 
 v1.0では以下の特徴があります:
-- シンプルで直感的なYAML構造（`spec`, `tree`, `file`）
+- シンプルで直感的なYAML構造（`tree`, `file`）
 - マルチプロジェクト対応
 - ファイル保護システムの実装
 - AI向け自動化機能の追加

--- a/moli.yml
+++ b/moli.yml
@@ -1,6 +1,6 @@
 - name: app_1
   lang: rust
-  spec:
+  tree:
     - name: src
       file:
         - name: main
@@ -13,7 +13,7 @@
 
 - name: app_2
   lang: rust
-  spec:
+  tree:
     - name: src
       file:
         - name: lib

--- a/src/cli/command/new.rs
+++ b/src/cli/command/new.rs
@@ -92,7 +92,7 @@ fn generate_new_moli_yml(project_name: &str, language: &str) -> Result<String> {
                 r#"- name: {}
   root: true
   lang: {}
-  spec:
+  tree:
     - name: src
       file:
         - name: {}
@@ -118,7 +118,7 @@ fn generate_new_moli_yml(project_name: &str, language: &str) -> Result<String> {
                 r#"- name: {}
   root: true
   lang: {}
-  spec:
+  tree:
     - name: src
       file:
         - name: {}
@@ -144,7 +144,7 @@ fn generate_new_moli_yml(project_name: &str, language: &str) -> Result<String> {
                 r#"- name: {}
   root: true
   lang: {}
-  spec:
+  tree:
     - name: src
       file:
         - name: {}
@@ -173,7 +173,7 @@ fn append_to_existing_moli_yml(project_name: &str, language: &str) -> Result<()>
 
 - name: {}
   lang: {}
-  spec:
+  tree:
     - name: src
       file:
         - name: {}
@@ -201,7 +201,7 @@ fn append_to_existing_moli_yml(project_name: &str, language: &str) -> Result<()>
 
 - name: {}
   lang: {}
-  spec:
+  tree:
     - name: src
       file:
         - name: {}
@@ -229,7 +229,7 @@ fn append_to_existing_moli_yml(project_name: &str, language: &str) -> Result<()>
 
 - name: {}
   lang: {}
-  spec:
+  tree:
     - name: src
       file:
         - name: {}

--- a/src/code_generation/core/directory_builder.rs
+++ b/src/code_generation/core/directory_builder.rs
@@ -24,7 +24,7 @@ impl DirectoryBuilder {
         };
 
         // Build module structure recursively
-        for module in project.spec() {
+        for module in project.tree() {
             Self::build_module_structure(&project_path, module)?;
         }
 
@@ -60,7 +60,7 @@ impl DirectoryBuilder {
             PathBuf::from(project.name())
         };
 
-        for module in project.spec() {
+        for module in project.tree() {
             Self::collect_module_directories(&base_path, module, &mut directories);
         }
 
@@ -101,7 +101,7 @@ impl DirectoryBuilder {
     ) -> Result<()> {
         if project.is_root() {
             // For root projects, only clean specific module directories
-            for module in project.spec() {
+            for module in project.tree() {
                 let module_path = base_path.as_ref().join(module.name());
                 if module_path.exists() {
                     fs::remove_dir_all(&module_path)

--- a/src/code_generation/core/file_builder.rs
+++ b/src/code_generation/core/file_builder.rs
@@ -33,12 +33,12 @@ impl FileBuilder {
         project: &Project,
     ) -> Result<()> {
         // Generate files in all modules
-        for module in project.spec() {
+        for module in project.tree() {
             Self::build_rust_module_files(&project_path, module, &[])?;
         }
 
         // Generate main.rs or lib.rs for src modules (only if explicitly specified)
-        if let Some(src_module) = project.spec().iter().find(|m| m.name() == "src") {
+        if let Some(src_module) = project.tree().iter().find(|m| m.name() == "src") {
             if RustModuleGenerator::should_generate_main_rs(project) {
                 RustModuleGenerator::generate_main_rs(&project_path, &[src_module.clone()])?;
             } else if RustModuleGenerator::should_generate_lib_rs(project) {
@@ -60,7 +60,7 @@ impl FileBuilder {
         TypeScriptModuleGenerator::generate_tsconfig_json(&project_path)?;
 
         // Generate files in all modules
-        for module in project.spec() {
+        for module in project.tree() {
             Self::build_typescript_module_files(&project_path, module, &[])?;
         }
 
@@ -90,7 +90,7 @@ impl FileBuilder {
         project_path: P,
         project: &Project,
     ) -> Result<()> {
-        for module in project.spec() {
+        for module in project.tree() {
             Self::build_generic_module_files(&project_path, module, project.language())?;
         }
         Ok(())
@@ -171,14 +171,14 @@ impl FileBuilder {
             PathBuf::from(project.name())
         };
 
-        for module in project.spec() {
+        for module in project.tree() {
             Self::collect_module_files(&base_path, module, project.language(), &mut files);
         }
 
         // Add language-specific files
         match project.language() {
             "rust" => {
-                if let Some(_) = project.spec().iter().find(|m| m.name() == "src") {
+                if let Some(_) = project.tree().iter().find(|m| m.name() == "src") {
                     files.push(base_path.join("src/main.rs"));
                 }
             }

--- a/src/code_generation/core/generator.rs
+++ b/src/code_generation/core/generator.rs
@@ -130,12 +130,12 @@ impl CodeGenerator {
         }
 
         // Generate module structure
-        for module in project.spec() {
+        for module in project.tree() {
             RustModuleGenerator::generate_module(project_path, module, &[])?;
         }
 
         // Generate main.rs or lib.rs
-        let src_modules: Vec<_> = project.spec().iter()
+        let src_modules: Vec<_> = project.tree().iter()
             .filter(|m| m.name() == "src")
             .cloned()
             .collect();
@@ -174,7 +174,7 @@ impl CodeGenerator {
         }
 
         // Generate module structure
-        for module in project.spec() {
+        for module in project.tree() {
             TypeScriptModuleGenerator::generate_module(project_path, module, &[])?;
         }
 

--- a/src/code_generation/language/any/file_handler.rs
+++ b/src/code_generation/language/any/file_handler.rs
@@ -38,7 +38,7 @@ impl AnyFileHandler {
         }
 
         // Generate module structure (directories and files)
-        for module in project.spec() {
+        for module in project.tree() {
             Self::generate_module(project_path, module)?;
         }
 

--- a/src/code_generation/language/go/mod_handler.rs
+++ b/src/code_generation/language/go/mod_handler.rs
@@ -61,7 +61,7 @@ impl GoModuleHandler {
         }
         
         // Generate module structure
-        for module in project.spec() {
+        for module in project.tree() {
             GoPackageGenerator::generate_module(project_path, module, &[])?;
         }
 

--- a/src/code_generation/language/go/package_generator.rs
+++ b/src/code_generation/language/go/package_generator.rs
@@ -145,7 +145,7 @@ func main() {
         let has_main_in_project = project.files().iter()
             .any(|f| f.name() == "main" || f.filename_with_extension("go") == "main.go");
         
-        let has_main_in_modules = project.spec().iter()
+        let has_main_in_modules = project.tree().iter()
             .flat_map(|m| Self::find_main_in_module(m))
             .any(|has_main| has_main);
         

--- a/src/code_generation/language/javascript/module_generator.rs
+++ b/src/code_generation/language/javascript/module_generator.rs
@@ -173,7 +173,7 @@ impl JavaScriptModuleGenerator {
         let has_index_in_project = project.files().iter()
             .any(|f| f.name() == "index" || f.filename_with_extension("javascript") == "index.js");
         
-        let has_index_in_modules = project.spec().iter()
+        let has_index_in_modules = project.tree().iter()
             .flat_map(|m| Self::find_index_in_module(m))
             .any(|has_index| has_index);
         

--- a/src/code_generation/language/javascript/package_handler.rs
+++ b/src/code_generation/language/javascript/package_handler.rs
@@ -40,7 +40,7 @@ impl JavaScriptPackageHandler {
         }
         
         // Generate module structure
-        for module in project.spec() {
+        for module in project.tree() {
             JavaScriptModuleGenerator::generate_module(project_path, module, &[])?;
         }
 

--- a/src/code_generation/language/python/init_handler.rs
+++ b/src/code_generation/language/python/init_handler.rs
@@ -43,7 +43,7 @@ impl PythonInitHandler {
         }
         
         // Generate module structure
-        for module in project.spec() {
+        for module in project.tree() {
             PythonPackageGenerator::generate_module(project_path, module, &[])?;
         }
 

--- a/src/code_generation/language/python/package_generator.rs
+++ b/src/code_generation/language/python/package_generator.rs
@@ -190,7 +190,7 @@ if __name__ == "__main__":
         let has_main_in_project = project.files().iter()
             .any(|f| f.name() == "main" || f.filename_with_extension("python") == "main.py");
         
-        let has_main_in_modules = project.spec().iter()
+        let has_main_in_modules = project.tree().iter()
             .flat_map(|m| Self::find_main_in_module(m))
             .any(|has_main| has_main);
         

--- a/src/code_generation/language/rust/cargo_handler.rs
+++ b/src/code_generation/language/rust/cargo_handler.rs
@@ -55,7 +55,7 @@ edition = "2024"
         let has_lib_in_project = project.files().iter()
             .any(|f| f.name() == "lib" || f.filename_with_extension("rust") == "lib.rs");
         
-        let has_lib_in_src = project.spec().iter()
+        let has_lib_in_src = project.tree().iter()
             .filter(|m| m.name() == "src")
             .flat_map(|m| m.files())
             .any(|f| f.name() == "lib" || f.filename_with_extension("rust") == "lib.rs");

--- a/src/code_generation/language/rust/module_generator.rs
+++ b/src/code_generation/language/rust/module_generator.rs
@@ -201,7 +201,7 @@ impl RustModuleGenerator {
         let has_main_in_project = project.files().iter()
             .any(|f| f.name() == "main" || f.filename_with_extension("rust") == "main.rs");
 
-        let has_main_in_src = project.spec().iter()
+        let has_main_in_src = project.tree().iter()
             .filter(|m| m.name() == "src")
             .flat_map(|m| m.files())
             .any(|f| f.name() == "main" || f.filename_with_extension("rust") == "main.rs");
@@ -214,7 +214,7 @@ impl RustModuleGenerator {
         let has_lib_in_project = project.files().iter()
             .any(|f| f.name() == "lib" || f.filename_with_extension("rust") == "lib.rs");
 
-        let has_lib_in_src = project.spec().iter()
+        let has_lib_in_src = project.tree().iter()
             .filter(|m| m.name() == "src")
             .flat_map(|m| m.files())
             .any(|f| f.name() == "lib" || f.filename_with_extension("rust") == "lib.rs");

--- a/src/project_management/config/models.rs
+++ b/src/project_management/config/models.rs
@@ -17,7 +17,7 @@ pub struct Project {
     #[serde(default)]
     pub file: Vec<CodeFile>,
     #[serde(default)]
-    pub spec: Vec<Module>,
+    pub tree: Vec<Module>,
 }
 
 /// Module or directory structure
@@ -78,9 +78,9 @@ impl Project {
         &self.lang
     }
 
-    /// Get top-level modules (spec)
-    pub fn spec(&self) -> &[Module] {
-        &self.spec
+    /// Get top-level modules (tree)
+    pub fn tree(&self) -> &[Module] {
+        &self.tree
     }
 
     /// Get all code files at project level

--- a/src/project_management/config/parser.rs
+++ b/src/project_management/config/parser.rs
@@ -50,7 +50,7 @@ mod tests {
 - name: app
   root: true
   lang: rust
-  spec:
+  tree:
     - name: src
       tree:
         - name: domain
@@ -68,7 +68,7 @@ mod tests {
         assert_eq!(project.name(), "app");
         assert!(project.is_root());
         assert_eq!(project.language(), "rust");
-        assert_eq!(project.spec().len(), 1);
+        assert_eq!(project.tree().len(), 1);
     }
 
     #[test]
@@ -76,14 +76,14 @@ mod tests {
         let yaml_content = r#"
 - name: backend
   lang: rust
-  spec:
+  tree:
     - name: src
       file:
         - name: main
 
 - name: frontend
   lang: javascript
-  spec:
+  tree:
     - name: src
       file:
         - name: index.js
@@ -110,7 +110,7 @@ mod tests {
         let yaml_content = r#"
 - name: app
   lang: rust
-  spec:
+  tree:
     - name: src
       file:
         - name: model
@@ -119,7 +119,7 @@ mod tests {
 
         let config = ConfigParser::parse_string(yaml_content).unwrap();
         let project = &config.projects()[0];
-        let files = &project.spec()[0].files();
+        let files = &project.tree()[0].files();
 
         // Test auto extension
         assert_eq!(files[0].filename_with_extension("rust"), "model.rs");

--- a/src/project_management/config/validator.rs
+++ b/src/project_management/config/validator.rs
@@ -76,9 +76,9 @@ impl ConfigValidator {
             });
         }
 
-        // Validate modules (spec)
-        for (i, module) in project.spec().iter().enumerate() {
-            if let Err(module_errors) = Self::validate_module(module, &format!("{}.spec[{}]", path, i)) {
+        // Validate modules (tree)
+        for (i, module) in project.tree().iter().enumerate() {
+            if let Err(module_errors) = Self::validate_module(module, &format!("{}.tree[{}]", path, i)) {
                 errors.extend(module_errors);
             }
         }
@@ -180,7 +180,7 @@ mod tests {
                 name: "app".to_string(),
                 root: true,
                 lang: "rust".to_string(),
-                spec: vec![],
+                tree: vec![],
                 file: vec![],
             }],
         };
@@ -196,14 +196,14 @@ mod tests {
                     name: "backend".to_string(),
                     root: false,
                     lang: "rust".to_string(),
-                    spec: vec![],
+                    tree: vec![],
                     file: vec![],
                 },
                 Project {
                     name: "frontend".to_string(),
                     root: false,
                     lang: "javascript".to_string(),
-                    spec: vec![],
+                    tree: vec![],
                     file: vec![],
                 },
             ],
@@ -220,14 +220,14 @@ mod tests {
                     name: "app1".to_string(),
                     root: true,
                     lang: "rust".to_string(),
-                    spec: vec![],
+                    tree: vec![],
                     file: vec![],
                 },
                 Project {
                     name: "app2".to_string(),
                     root: true,
                     lang: "go".to_string(),
-                    spec: vec![],
+                    tree: vec![],
                     file: vec![],
                 },
             ],
@@ -244,14 +244,14 @@ mod tests {
                     name: "app".to_string(),
                     root: false,
                     lang: "rust".to_string(),
-                    spec: vec![],
+                    tree: vec![],
                     file: vec![],
                 },
                 Project {
                     name: "app".to_string(),
                     root: false,
                     lang: "go".to_string(),
-                    spec: vec![],
+                    tree: vec![],
                     file: vec![],
                 },
             ],
@@ -267,7 +267,7 @@ mod tests {
                 name: "app".to_string(),
                 root: true,
                 lang: "cobol".to_string(),
-                spec: vec![],
+                tree: vec![],
                 file: vec![],
             }],
         };


### PR DESCRIPTION
プロジェクトのトップレベル構造を定義するキーを`spec`から`tree`に変更し、
ネストされた構造と一貫性を持たせた。

- models.rsのフィールドとメソッドを変更
- 全ての言語ジェネレータでproject.spec()をproject.tree()に更新
- new.rsのYAML生成テンプレートを更新
- moli.ymlサンプルファイルを更新
- README.mdのドキュメントを更新