### PR TITLE
v1.2.0 moli loadサブコマンドを追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +208,31 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -265,6 +300,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +331,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
 dependencies = [
  "libm",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -410,12 +474,13 @@ dependencies = [
 
 [[package]]
 name = "moli"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "askama",
  "clap",
  "clap_complete",
+ "ignore",
  "inquire",
  "regex",
  "serde",
@@ -573,6 +638,15 @@ name = "ryu"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -747,6 +821,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,6 +860,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moli"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 
 [[bin]]
@@ -17,6 +17,7 @@ regex = "1.10.2"
 yaml-rust = "0.4.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
+ignore = "0.4"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/src/cli/command/load.rs
+++ b/src/cli/command/load.rs
@@ -1,0 +1,295 @@
+use clap::Command;
+use anyhow::{bail, Context, Result};
+use inquire::{Select, Confirm};
+use std::fs;
+use std::path::Path;
+
+use crate::project_management::config::{ConfigParser, ConfigValidator};
+use crate::project_management::config::filesystem_scanner::{FilesystemScanner, UnmanagedEntry};
+use crate::project_management::config::yaml_modifier::{YamlModifier, AddChild};
+use crate::shared::utils::diff::show_diff;
+
+pub fn spec() -> Command {
+    Command::new("load")
+        .about("Load unmanaged files or directories into moli.yml")
+        .long_about(
+            "Interactively select and add a file or directory to moli.yml.\n\
+            \n\
+            This command will:\n\
+            1. Scan the filesystem for files/directories not in .gitignore\n\
+            2. Filter out entries already managed by moli.yml\n\
+            3. Let you search and select an entry to add\n\
+            4. Generate the moli.yml entry (with diff preview)\n\
+            5. Update moli.yml with confirmation\n\
+            \n\
+            Directories are shown with a trailing '/' and selecting one\n\
+            will also add all files and subdirectories within it."
+        )
+}
+
+pub fn action() -> Result<()> {
+    // Check if moli.yml exists
+    if !ConfigParser::config_exists() {
+        bail!("moli.yml not found. Run 'moli new' to create a new project configuration.");
+    }
+
+    // Parse configuration
+    let config = ConfigParser::parse_default()
+        .context("Failed to parse moli.yml")?;
+
+    // Validate configuration
+    ConfigValidator::validate(&config)
+        .context("Configuration validation failed")?;
+
+    // Scan filesystem for unmanaged entries
+    let all_entries = FilesystemScanner::scan(&config)
+        .context("Failed to scan filesystem")?;
+
+    if all_entries.is_empty() {
+        println!("No unmanaged files or directories found.");
+        return Ok(());
+    }
+
+    // Pre-filter: exclude entries that would produce no changes in moli.yml
+    let yaml_content = fs::read_to_string("moli.yml")
+        .context("Failed to read moli.yml")?;
+
+    let unmanaged_entries: Vec<UnmanagedEntry> = all_entries
+        .into_iter()
+        .filter(|entry| would_produce_changes(&config, &yaml_content, entry))
+        .collect();
+
+    if unmanaged_entries.is_empty() {
+        println!("No unmanaged files or directories found.");
+        return Ok(());
+    }
+
+    // Build display options
+    let display_options: Vec<String> = unmanaged_entries
+        .iter()
+        .map(|e| e.display_path.clone())
+        .collect();
+
+    // Interactive selection with fuzzy search
+    let selected = Select::new("Select a file or directory to add to moli.yml:", display_options)
+        .prompt()
+        .context("Selection cancelled")?;
+
+    // Find the selected entry
+    let target = unmanaged_entries
+        .iter()
+        .find(|e| e.display_path == selected)
+        .unwrap();
+
+    // Determine which project to add to
+    let (project_index, path_segments) = resolve_project(&config, target)?;
+    let language = config.projects()[project_index].language();
+
+    // Collect children if directory
+    let children = if target.is_directory {
+        collect_directory_children(&target.relative_path)?
+    } else {
+        vec![]
+    };
+
+    // Generate new YAML
+    let new_yaml = if path_segments.is_empty() && target.is_directory {
+        // Selected directory is the project root itself.
+        // Add each child directly to the project.
+        let mut result = yaml_content.clone();
+        for child in &children {
+            let child_path = vec![child.name.clone()];
+            result = YamlModifier::add_entry(
+                &result,
+                project_index,
+                &child_path,
+                child.is_directory,
+                language,
+                &child.children,
+            ).context("Failed to modify moli.yml")?;
+        }
+        result
+    } else {
+        YamlModifier::add_entry(
+            &yaml_content,
+            project_index,
+            &path_segments,
+            target.is_directory,
+            language,
+            &children,
+        ).context("Failed to modify moli.yml")?
+    };
+
+    if yaml_content == new_yaml {
+        println!("No changes needed. Entry may already exist in moli.yml.");
+        return Ok(());
+    }
+
+    // Show diff
+    println!();
+    println!("Changes to moli.yml:");
+    println!("---");
+    show_diff(&yaml_content, &new_yaml);
+    println!("---");
+
+    let confirm = Confirm::new("Apply changes to moli.yml?")
+        .with_default(true)
+        .prompt()
+        .context("Confirmation cancelled")?;
+
+    if !confirm {
+        println!("moli.yml was not modified.");
+        return Ok(());
+    }
+
+    fs::write("moli.yml", &new_yaml)
+        .context("Failed to write moli.yml")?;
+    println!("  ✓ Updated moli.yml");
+
+    println!("[Success] '{}' has been added to moli.yml.", selected);
+    Ok(())
+}
+
+/// Determine which project the entry belongs to and compute path segments relative to that project.
+fn resolve_project(
+    config: &crate::project_management::config::models::MoliConfig,
+    entry: &UnmanagedEntry,
+) -> Result<(usize, Vec<String>)> {
+    let projects = config.projects();
+
+    // Check for root project first
+    if let Some((idx, _)) = projects.iter().enumerate().find(|(_, p)| p.is_root()) {
+        // Root project: path segments are the full relative path components
+        let segments: Vec<String> = entry.relative_path
+            .components()
+            .filter_map(|c| match c {
+                std::path::Component::Normal(n) => Some(n.to_string_lossy().to_string()),
+                _ => None,
+            })
+            .collect();
+        return Ok((idx, segments));
+    }
+
+    // Non-root projects: check first path segment against project names
+    let components: Vec<String> = entry.relative_path
+        .components()
+        .filter_map(|c| match c {
+            std::path::Component::Normal(n) => Some(n.to_string_lossy().to_string()),
+            _ => None,
+        })
+        .collect();
+
+    if components.is_empty() {
+        bail!("Cannot resolve empty path to a project");
+    }
+
+    let first_segment = &components[0];
+
+    // Check if first segment matches any project name
+    if let Some((idx, _)) = projects.iter().enumerate().find(|(_, p)| p.name() == first_segment) {
+        // Remove the project name from segments
+        let segments = components[1..].to_vec();
+        return Ok((idx, segments));
+    }
+
+    // No matching project found - use or create "." project
+    if let Some((idx, _)) = projects.iter().enumerate().find(|(_, p)| p.name() == ".") {
+        return Ok((idx, components));
+    }
+
+    // Need to create "." project - for now, bail with a message
+    bail!(
+        "No matching project found for '{}'. \
+        Consider adding a project with `- name: .` to moli.yml, \
+        or add the entry under an existing project directory.",
+        entry.display_path
+    );
+}
+
+/// Check if adding an entry would produce changes in moli.yml
+fn would_produce_changes(
+    config: &crate::project_management::config::models::MoliConfig,
+    yaml_content: &str,
+    entry: &UnmanagedEntry,
+) -> bool {
+    let (project_index, path_segments) = match resolve_project(config, entry) {
+        Ok(v) => v,
+        Err(_) => return true, // Keep entries that fail to resolve (let user see the error)
+    };
+    let language = config.projects()[project_index].language();
+
+    let children = if entry.is_directory {
+        match collect_directory_children(&entry.relative_path) {
+            Ok(c) => c,
+            Err(_) => return true,
+        }
+    } else {
+        vec![]
+    };
+
+    let new_yaml = if path_segments.is_empty() && entry.is_directory {
+        let mut result = yaml_content.to_string();
+        for child in &children {
+            let child_path = vec![child.name.clone()];
+            match YamlModifier::add_entry(
+                &result, project_index, &child_path,
+                child.is_directory, language, &child.children,
+            ) {
+                Ok(r) => result = r,
+                Err(_) => return true,
+            }
+        }
+        result
+    } else {
+        match YamlModifier::add_entry(
+            yaml_content, project_index, &path_segments,
+            entry.is_directory, language, &children,
+        ) {
+            Ok(r) => r,
+            Err(_) => return true,
+        }
+    };
+
+    yaml_content != new_yaml
+}
+
+/// Collect all children of a directory as AddChild tree using ignore crate
+fn collect_directory_children(dir_path: &Path) -> Result<Vec<AddChild>> {
+    use ignore::WalkBuilder;
+
+    let mut paths = Vec::new();
+
+    let walker = WalkBuilder::new(dir_path)
+        .hidden(true)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        .build();
+
+    for result in walker {
+        let entry = result.context("Failed to read directory entry")?;
+        let path = entry.path();
+
+        // Skip the root directory itself
+        if path == dir_path {
+            continue;
+        }
+
+        // Skip managed/excluded files
+        if let Some(file_name) = path.file_name() {
+            let name = file_name.to_string_lossy();
+            let skip_files = [
+                "mod.rs", "__init__.py", "index.ts", "index.js",
+                "Cargo.toml", "Cargo.lock", "package.json", "package-lock.json",
+                "go.mod", "go.sum", ".gitignore",
+            ];
+            if skip_files.contains(&name.as_ref()) {
+                continue;
+            }
+        }
+
+        paths.push(path.to_path_buf());
+    }
+
+    Ok(AddChild::from_paths(&paths, dir_path))
+}

--- a/src/cli/command/mod.rs
+++ b/src/cli/command/mod.rs
@@ -2,6 +2,7 @@
 pub mod new;
 pub mod up;
 pub mod rm;
+pub mod load;
 pub mod ai_init;
 pub mod completion;
 // end auto exported by moli.

--- a/src/cli/command/rm.rs
+++ b/src/cli/command/rm.rs
@@ -7,10 +7,7 @@ use std::path::Path;
 use crate::project_management::config::{ConfigParser, ConfigValidator};
 use crate::project_management::config::path_collector::PathCollector;
 use crate::project_management::config::yaml_modifier::YamlModifier;
-
-const RED: &str = "\x1b[31m";
-const GREEN: &str = "\x1b[32m";
-const RESET: &str = "\x1b[0m";
+use crate::shared::utils::diff::show_diff;
 
 pub fn spec() -> Command {
     Command::new("rm")
@@ -141,42 +138,3 @@ pub fn action() -> Result<()> {
     Ok(())
 }
 
-fn show_diff(old: &str, new: &str) {
-    let old_lines: Vec<&str> = old.lines().collect();
-    let new_lines: Vec<&str> = new.lines().collect();
-
-    let mut old_idx = 0;
-    let mut new_idx = 0;
-
-    while old_idx < old_lines.len() || new_idx < new_lines.len() {
-        if old_idx < old_lines.len() && new_idx < new_lines.len() {
-            if old_lines[old_idx] == new_lines[new_idx] {
-                println!("  {}", old_lines[old_idx]);
-                old_idx += 1;
-                new_idx += 1;
-            } else {
-                let mut found = false;
-                for ahead in 0..old_lines.len() - old_idx {
-                    if new_idx < new_lines.len() && old_lines[old_idx + ahead] == new_lines[new_idx] {
-                        for k in 0..ahead {
-                            println!("{}- {}{}", RED, old_lines[old_idx + k], RESET);
-                        }
-                        old_idx += ahead;
-                        found = true;
-                        break;
-                    }
-                }
-                if !found {
-                    println!("{}- {}{}", RED, old_lines[old_idx], RESET);
-                    old_idx += 1;
-                }
-            }
-        } else if old_idx < old_lines.len() {
-            println!("{}- {}{}", RED, old_lines[old_idx], RESET);
-            old_idx += 1;
-        } else {
-            println!("{}+ {}{}", GREEN, new_lines[new_idx], RESET);
-            new_idx += 1;
-        }
-    }
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,9 @@ fn main() -> anyhow::Result<()> {
             command::rm::spec()
         )
         .subcommand(
+            command::load::spec()
+        )
+        .subcommand(
             command::ai_init::spec()
         )
         .subcommand(
@@ -49,6 +52,9 @@ fn main() -> anyhow::Result<()> {
         }
         Some(("rm", _)) => {
             command::rm::action()
+        }
+        Some(("load", _)) => {
+            command::load::action()
         }
         Some(("ai-init", _)) => {
             command::ai_init::action()

--- a/src/project_management/config/filesystem_scanner.rs
+++ b/src/project_management/config/filesystem_scanner.rs
@@ -1,0 +1,237 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use anyhow::{Context, Result};
+use ignore::WalkBuilder;
+use crate::project_management::config::models::MoliConfig;
+use crate::project_management::config::path_collector::PathCollector;
+
+/// Represents a file or directory on the filesystem that is NOT managed by moli.yml
+#[derive(Debug, Clone)]
+pub struct UnmanagedEntry {
+    /// Display path (e.g., "src/utils/" or "src/utils/helper.rs")
+    pub display_path: String,
+    /// Relative path from project root
+    pub relative_path: PathBuf,
+    /// Whether this entry is a directory
+    pub is_directory: bool,
+}
+
+/// Files that moli manages automatically (should not be shown to users)
+const MANAGED_FILES: &[&str] = &[
+    "mod.rs",
+    "__init__.py",
+    "index.ts",
+    "index.js",
+];
+
+/// Config/meta files that should be excluded from load candidates
+const EXCLUDED_FILES: &[&str] = &[
+    "moli.yml",
+    "Cargo.toml",
+    "Cargo.lock",
+    "package.json",
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "go.mod",
+    "go.sum",
+    "pyproject.toml",
+    "setup.py",
+    "setup.cfg",
+    ".gitignore",
+    ".gitattributes",
+];
+
+/// Directories that should always be excluded
+const EXCLUDED_DIRS: &[&str] = &[
+    ".git",
+    "node_modules",
+    "target",
+    "__pycache__",
+    ".venv",
+    "venv",
+];
+
+pub struct FilesystemScanner;
+
+impl FilesystemScanner {
+    /// Scan the filesystem and return entries not managed by moli.yml
+    pub fn scan(config: &MoliConfig) -> Result<Vec<UnmanagedEntry>> {
+        // Collect all managed paths from moli.yml
+        let managed_entries = PathCollector::collect_all_entries(config);
+        let managed_paths: HashSet<String> = managed_entries
+            .iter()
+            .map(|e| e.display_path.clone())
+            .collect();
+
+        let mut entries = Vec::new();
+        let excluded_files: HashSet<&str> = EXCLUDED_FILES.iter().copied().collect();
+        let managed_files: HashSet<&str> = MANAGED_FILES.iter().copied().collect();
+        let excluded_dirs: HashSet<&str> = EXCLUDED_DIRS.iter().copied().collect();
+
+        // Walk the filesystem respecting .gitignore
+        let walker = WalkBuilder::new(".")
+            .hidden(true)       // skip hidden files
+            .git_ignore(true)   // respect .gitignore
+            .git_global(true)   // respect global gitignore
+            .git_exclude(true)  // respect .git/info/exclude
+            .build();
+
+        for result in walker {
+            let entry = result.context("Failed to read directory entry")?;
+            let path = entry.path();
+
+            // Skip the root directory itself
+            if path == Path::new(".") {
+                continue;
+            }
+
+            // Get relative path (strip leading ./)
+            let relative = path.strip_prefix("./").unwrap_or(path);
+            let relative_str = relative.to_string_lossy();
+
+            // Skip excluded directories
+            if entry.file_type().map_or(false, |ft| ft.is_dir()) {
+                if let Some(name) = relative.file_name() {
+                    if excluded_dirs.contains(name.to_string_lossy().as_ref()) {
+                        continue;
+                    }
+                }
+            }
+
+            // Skip excluded files
+            if let Some(file_name) = relative.file_name() {
+                let name = file_name.to_string_lossy();
+                if excluded_files.contains(name.as_ref()) {
+                    continue;
+                }
+                // Skip moli-managed module files
+                if managed_files.contains(name.as_ref()) {
+                    continue;
+                }
+            }
+
+            let is_dir = entry.file_type().map_or(false, |ft| ft.is_dir());
+            let display_path = if is_dir {
+                format!("{}/", relative_str)
+            } else {
+                relative_str.to_string()
+            };
+
+            // Skip if already managed by moli.yml
+            if managed_paths.contains(&display_path) {
+                continue;
+            }
+
+            // For files, also check without extension (moli.yml may omit standard extensions)
+            if !is_dir {
+                let without_ext = Self::strip_standard_extension(&relative_str);
+                if let Some(stem) = without_ext {
+                    // Check if a managed path matches the stem version
+                    let stem_managed = managed_entries.iter().any(|e| {
+                        !e.is_directory && e.display_path == display_path
+                    });
+                    if stem_managed {
+                        continue;
+                    }
+                    // Also check by reconstructing what moli would generate
+                    let _ = stem; // already checked via display_path above
+                }
+            }
+
+            entries.push(UnmanagedEntry {
+                display_path,
+                relative_path: relative.to_path_buf(),
+                is_directory: is_dir,
+            });
+        }
+
+        // Sort: directories first, then alphabetically
+        entries.sort_by(|a, b| {
+            match (a.is_directory, b.is_directory) {
+                (true, false) => std::cmp::Ordering::Less,
+                (false, true) => std::cmp::Ordering::Greater,
+                _ => a.display_path.cmp(&b.display_path),
+            }
+        });
+
+        Ok(entries)
+    }
+
+    /// Strip standard language extension from a filename, returning the stem if applicable
+    fn strip_standard_extension(path: &str) -> Option<String> {
+        let standard_extensions = [".rs", ".go", ".py", ".ts", ".js"];
+        for ext in &standard_extensions {
+            if path.ends_with(ext) {
+                return Some(path[..path.len() - ext.len()].to_string());
+            }
+        }
+        None
+    }
+
+    /// Remove the standard language extension from a filename for moli.yml entry
+    pub fn filename_without_standard_extension(filename: &str, language: &str) -> String {
+        let ext = match language {
+            "rust" => ".rs",
+            "go" => ".go",
+            "python" => ".py",
+            "typescript" => ".ts",
+            "javascript" => ".js",
+            _ => return filename.to_string(),
+        };
+        if filename.ends_with(ext) {
+            filename[..filename.len() - ext.len()].to_string()
+        } else {
+            filename.to_string()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_standard_extension() {
+        assert_eq!(
+            FilesystemScanner::strip_standard_extension("model.rs"),
+            Some("model".to_string())
+        );
+        assert_eq!(
+            FilesystemScanner::strip_standard_extension("handler.go"),
+            Some("handler".to_string())
+        );
+        assert_eq!(
+            FilesystemScanner::strip_standard_extension("App.tsx"),
+            None
+        );
+        assert_eq!(
+            FilesystemScanner::strip_standard_extension("README.md"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_filename_without_standard_extension() {
+        assert_eq!(
+            FilesystemScanner::filename_without_standard_extension("model.rs", "rust"),
+            "model"
+        );
+        assert_eq!(
+            FilesystemScanner::filename_without_standard_extension("handler.go", "go"),
+            "handler"
+        );
+        assert_eq!(
+            FilesystemScanner::filename_without_standard_extension("App.tsx", "typescript"),
+            "App.tsx"
+        );
+        assert_eq!(
+            FilesystemScanner::filename_without_standard_extension("main.py", "python"),
+            "main"
+        );
+        assert_eq!(
+            FilesystemScanner::filename_without_standard_extension("config.yaml", "rust"),
+            "config.yaml"
+        );
+    }
+}

--- a/src/project_management/config/mod.rs
+++ b/src/project_management/config/mod.rs
@@ -4,9 +4,9 @@ pub mod validator;
 pub mod models;
 pub mod path_collector;
 pub mod yaml_modifier;
+pub mod filesystem_scanner;
 // end auto exported by moli.
 
 // Re-exports for convenience
-pub use models::*;
 pub use parser::ConfigParser;
 pub use validator::ConfigValidator;

--- a/src/project_management/config/yaml_modifier.rs
+++ b/src/project_management/config/yaml_modifier.rs
@@ -1,5 +1,8 @@
+use std::collections::BTreeMap;
+use std::path::Path;
 use anyhow::{Result, bail};
 use crate::project_management::config::path_collector::ManagedFile;
+use crate::project_management::config::filesystem_scanner::FilesystemScanner;
 
 pub struct YamlModifier;
 
@@ -360,6 +363,658 @@ impl YamlModifier {
 
         result.join("\n")
     }
+
+    // ========== Add Entry Logic ==========
+
+    /// Add a file or directory entry to YAML content at the appropriate position in a project.
+    /// `path_segments` is the path components relative to the project root (e.g., ["src", "domain", "model.rs"]).
+    /// `is_directory` indicates whether the entry itself is a directory.
+    /// `language` is the project language for extension stripping.
+    /// `project_index` is which project in the YAML to modify.
+    /// `children` contains child entries when adding a directory (sub-dirs and files found inside).
+    pub fn add_entry(
+        yaml_content: &str,
+        project_index: usize,
+        path_segments: &[String],
+        is_directory: bool,
+        language: &str,
+        children: &[AddChild],
+    ) -> Result<String> {
+        if path_segments.is_empty() {
+            bail!("Cannot add entry with empty path");
+        }
+
+        let mut result = yaml_content.to_string();
+
+        if is_directory {
+            // Adding a directory: need to add as tree entry, then recursively add children
+            result = Self::ensure_tree_path(&result, project_index, path_segments)?;
+
+            // Add children (files and subdirectories)
+            for child in children {
+                result = Self::add_child_recursive(&result, project_index, path_segments, child, language)?;
+            }
+        } else {
+            // Adding a single file
+            let dir_path = &path_segments[..path_segments.len() - 1];
+            let file_name = &path_segments[path_segments.len() - 1];
+            let moli_name = FilesystemScanner::filename_without_standard_extension(file_name, language);
+
+            if dir_path.is_empty() {
+                // Project-level file
+                result = Self::add_project_level_file(&result, project_index, &moli_name)?;
+            } else {
+                // File inside tree
+                result = Self::ensure_tree_path(&result, project_index, dir_path)?;
+                result = Self::add_file_to_module(&result, project_index, dir_path, &moli_name)?;
+            }
+        }
+
+        // Preserve trailing newline
+        if yaml_content.ends_with('\n') && !result.ends_with('\n') {
+            result.push('\n');
+        }
+
+        Ok(result)
+    }
+
+    /// Recursively add children (files/subdirs) under a parent directory path
+    fn add_child_recursive(
+        yaml_content: &str,
+        project_index: usize,
+        parent_segments: &[String],
+        child: &AddChild,
+        language: &str,
+    ) -> Result<String> {
+        let mut full_path = parent_segments.to_vec();
+        full_path.push(child.name.clone());
+
+        if child.is_directory {
+            let mut result = Self::ensure_tree_path(yaml_content, project_index, &full_path)?;
+            for sub_child in &child.children {
+                result = Self::add_child_recursive(&result, project_index, &full_path, sub_child, language)?;
+            }
+            Ok(result)
+        } else {
+            let moli_name = FilesystemScanner::filename_without_standard_extension(&child.name, language);
+            Self::add_file_to_module(yaml_content, project_index, parent_segments, &moli_name)
+        }
+    }
+
+    /// Ensure a tree path exists in the YAML (create tree entries as needed).
+    /// `segments` are the directory names (e.g., ["src", "domain"]).
+    fn ensure_tree_path(
+        yaml_content: &str,
+        project_index: usize,
+        segments: &[String],
+    ) -> Result<String> {
+        let mut result = yaml_content.to_string();
+
+        for depth in 0..segments.len() {
+            let current_segments = &segments[..=depth];
+            if !Self::module_exists(&result, project_index, current_segments) {
+                let parent = &current_segments[..current_segments.len() - 1];
+                let module_name = &current_segments[current_segments.len() - 1];
+                result = Self::add_module(&result, project_index, parent, module_name)?;
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Check if a module path already exists in the YAML
+    fn module_exists(yaml_content: &str, project_index: usize, segments: &[String]) -> bool {
+        let lines: Vec<&str> = yaml_content.lines().collect();
+
+        if segments.is_empty() {
+            return true;
+        }
+
+        if segments.len() == 1 {
+            // Top-level module
+            return Self::find_top_level_module(&lines, project_index, &segments[0])
+                .ok()
+                .flatten()
+                .is_some();
+        }
+
+        // Navigate to parent first
+        let mut search_start = 0;
+        for seg in &segments[..segments.len() - 1] {
+            match Self::find_module_start(&lines, search_start, seg) {
+                Ok(Some(idx)) => search_start = idx + 1,
+                _ => return false,
+            }
+        }
+
+        Self::find_module_start(&lines, search_start, segments.last().unwrap())
+            .ok()
+            .flatten()
+            .is_some()
+    }
+
+    /// Add a module (directory) entry under a parent path
+    fn add_module(
+        yaml_content: &str,
+        project_index: usize,
+        parent_segments: &[String],
+        module_name: &str,
+    ) -> Result<String> {
+        let lines: Vec<&str> = yaml_content.lines().collect();
+
+        if parent_segments.is_empty() {
+            // Add as top-level tree entry in project
+            Self::add_top_level_module(&lines, project_index, module_name)
+        } else {
+            // Add as nested tree entry
+            Self::add_nested_module(&lines, project_index, parent_segments, module_name)
+        }
+    }
+
+    /// Add a top-level module to a project's tree section
+    fn add_top_level_module(
+        lines: &[&str],
+        project_index: usize,
+        module_name: &str,
+    ) -> Result<String> {
+        let mut result_lines: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
+        let mut current_project: i32 = -1;
+        let mut tree_line = None;
+        let mut insert_pos = None;
+
+        for (i, line) in lines.iter().enumerate() {
+            let trimmed = line.trim();
+
+            if trimmed.starts_with("- name:") && Self::line_indent(line) == 0 {
+                current_project += 1;
+                if current_project as usize > project_index {
+                    // We've passed our project, insert before this project
+                    insert_pos = Some(i);
+                    break;
+                }
+            }
+
+            if current_project as usize == project_index {
+                if trimmed == "tree:" && Self::line_indent(line) == 2 {
+                    tree_line = Some(i);
+                }
+                // Find the last entry in this project's tree section
+                if tree_line.is_some() && Self::line_indent(line) == 4 && trimmed.starts_with("- name:") {
+                    // Track last tree entry
+                    // Find end of this module block
+                    let mut end = i;
+                    for j in (i + 1)..lines.len() {
+                        let next_trimmed = lines[j].trim();
+                        let next_indent = Self::line_indent(lines[j]);
+                        if next_trimmed.is_empty() {
+                            continue;
+                        }
+                        if next_indent > 4 {
+                            end = j;
+                        } else {
+                            break;
+                        }
+                    }
+                    insert_pos = Some(end + 1);
+                }
+            }
+        }
+
+        if tree_line.is_none() {
+            // No tree: section exists, create one at the end of the project
+            let project_end = Self::find_project_end(lines, project_index);
+            let new_lines = format!("  tree:\n    - name: {}", module_name);
+            result_lines.insert(project_end, new_lines);
+        } else if let Some(pos) = insert_pos {
+            let new_line = format!("    - name: {}", module_name);
+            result_lines.insert(pos, new_line);
+        }
+
+        Ok(result_lines.join("\n"))
+    }
+
+    /// Add a nested module under a parent module
+    fn add_nested_module(
+        lines: &[&str],
+        project_index: usize,
+        parent_segments: &[String],
+        module_name: &str,
+    ) -> Result<String> {
+        let mut result_lines: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
+
+        // Find the parent module
+        let mut search_start = 0;
+        // First, navigate to the correct project
+        let mut current_project: i32 = -1;
+        for (i, line) in lines.iter().enumerate() {
+            let trimmed = line.trim();
+            if trimmed.starts_with("- name:") && Self::line_indent(line) == 0 {
+                current_project += 1;
+                if current_project as usize == project_index {
+                    search_start = i;
+                    break;
+                }
+            }
+        }
+
+        for seg in parent_segments {
+            match Self::find_module_start(lines, search_start, seg)? {
+                Some(idx) => search_start = idx + 1,
+                None => bail!("Could not find parent module '{}' in moli.yml", seg),
+            }
+        }
+
+        // search_start - 1 is the parent module's `- name:` line
+        let parent_start = search_start - 1;
+        let parent_indent = Self::line_indent(lines[parent_start]);
+        let tree_indent = parent_indent + 2;
+        let entry_indent = parent_indent + 4;
+
+        // Look for an existing tree: section in this parent
+        let mut tree_section_found = false;
+        let mut insert_pos = None;
+
+        for i in (parent_start + 1)..lines.len() {
+            let trimmed = lines[i].trim();
+            let indent = Self::line_indent(lines[i]);
+
+            if !trimmed.is_empty() && indent <= parent_indent {
+                break; // Left the parent module
+            }
+
+            if trimmed == "tree:" && indent == tree_indent {
+                tree_section_found = true;
+                continue;
+            }
+
+            if tree_section_found {
+                if indent == entry_indent && trimmed.starts_with("- name:") {
+                    // Track to find last entry in tree section
+                    let mut end = i;
+                    for j in (i + 1)..lines.len() {
+                        let next_trimmed = lines[j].trim();
+                        let next_indent = Self::line_indent(lines[j]);
+                        if next_trimmed.is_empty() {
+                            continue;
+                        }
+                        if next_indent > entry_indent {
+                            end = j;
+                        } else {
+                            break;
+                        }
+                    }
+                    insert_pos = Some(end + 1);
+                }
+            }
+        }
+
+        if !tree_section_found {
+            // Need to create tree: section at end of parent module
+            let mut parent_end = parent_start;
+            for i in (parent_start + 1)..lines.len() {
+                let trimmed = lines[i].trim();
+                let indent = Self::line_indent(lines[i]);
+                if !trimmed.is_empty() && indent <= parent_indent {
+                    break;
+                }
+                if !trimmed.is_empty() {
+                    parent_end = i;
+                }
+            }
+            let tree_line = format!("{}tree:", " ".repeat(tree_indent));
+            let entry_line = format!("{}- name: {}", " ".repeat(entry_indent), module_name);
+            result_lines.insert(parent_end + 1, tree_line);
+            result_lines.insert(parent_end + 2, entry_line);
+        } else if let Some(pos) = insert_pos {
+            let new_line = format!("{}- name: {}", " ".repeat(entry_indent), module_name);
+            result_lines.insert(pos, new_line);
+        } else {
+            // tree: section exists but is empty (shouldn't happen with valid data)
+            // Find tree: line and insert after it
+            for i in (parent_start + 1)..lines.len() {
+                let trimmed = lines[i].trim();
+                let indent = Self::line_indent(lines[i]);
+                if trimmed == "tree:" && indent == tree_indent {
+                    let new_line = format!("{}- name: {}", " ".repeat(entry_indent), module_name);
+                    result_lines.insert(i + 1, new_line);
+                    break;
+                }
+            }
+        }
+
+        Ok(result_lines.join("\n"))
+    }
+
+    /// Add a file to a module's file section
+    fn add_file_to_module(
+        yaml_content: &str,
+        project_index: usize,
+        module_segments: &[String],
+        file_name: &str,
+    ) -> Result<String> {
+        let lines: Vec<&str> = yaml_content.lines().collect();
+        let mut result_lines: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
+
+        // Find the target module
+        let mut search_start = 0;
+        let mut current_project: i32 = -1;
+        for (i, line) in lines.iter().enumerate() {
+            let trimmed = line.trim();
+            if trimmed.starts_with("- name:") && Self::line_indent(line) == 0 {
+                current_project += 1;
+                if current_project as usize == project_index {
+                    search_start = i;
+                    break;
+                }
+            }
+        }
+
+        for seg in module_segments {
+            match Self::find_module_start(&lines, search_start, seg)? {
+                Some(idx) => search_start = idx + 1,
+                None => bail!("Could not find module '{}' in moli.yml", seg),
+            }
+        }
+
+        let module_start = search_start - 1;
+        let module_indent = Self::line_indent(lines[module_start]);
+        let file_section_indent = module_indent + 2;
+        let file_entry_indent = module_indent + 4;
+
+        // Check if file already exists
+        let mut in_file_section = false;
+        for i in (module_start + 1)..lines.len() {
+            let trimmed = lines[i].trim();
+            let indent = Self::line_indent(lines[i]);
+
+            if !trimmed.is_empty() && indent <= module_indent {
+                break;
+            }
+
+            if trimmed == "file:" && indent == file_section_indent {
+                in_file_section = true;
+                continue;
+            }
+
+            if in_file_section && indent == file_entry_indent {
+                let expected = format!("- name: {}", file_name);
+                if trimmed == expected {
+                    // File already exists, skip
+                    return Ok(yaml_content.to_string());
+                }
+            }
+        }
+
+        // Find or create file: section and add entry
+        let mut file_section_found = false;
+        let mut insert_pos = None;
+
+        for i in (module_start + 1)..lines.len() {
+            let trimmed = lines[i].trim();
+            let indent = Self::line_indent(lines[i]);
+
+            if !trimmed.is_empty() && indent <= module_indent {
+                break;
+            }
+
+            if trimmed == "file:" && indent == file_section_indent {
+                file_section_found = true;
+                insert_pos = Some(i + 1); // Default: right after file:
+                continue;
+            }
+
+            if file_section_found && indent == file_entry_indent && trimmed.starts_with("- name:") {
+                // Track to find last file entry (including any sub-properties like pub:)
+                let mut end = i;
+                for j in (i + 1)..lines.len() {
+                    let next_trimmed = lines[j].trim();
+                    let next_indent = Self::line_indent(lines[j]);
+                    if next_trimmed.is_empty() {
+                        break;
+                    }
+                    if next_indent > file_entry_indent && !next_trimmed.starts_with("- name:") {
+                        end = j;
+                    } else {
+                        break;
+                    }
+                }
+                insert_pos = Some(end + 1);
+            }
+
+            // If we hit tree: at the same indent, stop looking for file entries
+            if file_section_found && trimmed == "tree:" && indent == file_section_indent {
+                break;
+            }
+        }
+
+        if !file_section_found {
+            // Need to create file: section. Insert before tree: section if it exists, or at end of module.
+            let mut tree_pos = None;
+            let mut module_content_end = module_start;
+
+            for i in (module_start + 1)..lines.len() {
+                let trimmed = lines[i].trim();
+                let indent = Self::line_indent(lines[i]);
+
+                if !trimmed.is_empty() && indent <= module_indent {
+                    break;
+                }
+
+                if !trimmed.is_empty() {
+                    module_content_end = i;
+                }
+
+                if trimmed == "tree:" && indent == file_section_indent {
+                    tree_pos = Some(i);
+                    break;
+                }
+            }
+
+            if let Some(tp) = tree_pos {
+                // Insert file: section before tree:
+                let file_line = format!("{}file:", " ".repeat(file_section_indent));
+                let entry_line = format!("{}- name: {}", " ".repeat(file_entry_indent), file_name);
+                result_lines.insert(tp, entry_line);
+                result_lines.insert(tp, file_line);
+            } else {
+                // Insert at end of module
+                let file_line = format!("{}file:", " ".repeat(file_section_indent));
+                let entry_line = format!("{}- name: {}", " ".repeat(file_entry_indent), file_name);
+                result_lines.insert(module_content_end + 1, file_line);
+                result_lines.insert(module_content_end + 2, entry_line);
+            }
+        } else if let Some(pos) = insert_pos {
+            let new_line = format!("{}- name: {}", " ".repeat(file_entry_indent), file_name);
+            result_lines.insert(pos, new_line);
+        }
+
+        Ok(result_lines.join("\n"))
+    }
+
+    /// Add a project-level file (directly under the project, not in tree)
+    fn add_project_level_file(
+        yaml_content: &str,
+        project_index: usize,
+        file_name: &str,
+    ) -> Result<String> {
+        let lines: Vec<&str> = yaml_content.lines().collect();
+        let mut result_lines: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
+
+        let mut current_project: i32 = -1;
+        let mut file_section_found = false;
+        let mut insert_pos = None;
+
+        for (i, line) in lines.iter().enumerate() {
+            let trimmed = line.trim();
+
+            if trimmed.starts_with("- name:") && Self::line_indent(line) == 0 {
+                current_project += 1;
+                file_section_found = false;
+            }
+
+            if current_project as usize != project_index {
+                continue;
+            }
+
+            if trimmed == "file:" && Self::line_indent(line) == 2 {
+                file_section_found = true;
+                insert_pos = Some(i + 1);
+                continue;
+            }
+
+            if file_section_found && Self::line_indent(line) == 4 && trimmed.starts_with("- name:") {
+                // Check for duplicate
+                let expected = format!("- name: {}", file_name);
+                if trimmed == expected {
+                    return Ok(yaml_content.to_string());
+                }
+                let mut end = i;
+                for j in (i + 1)..lines.len() {
+                    let next_trimmed = lines[j].trim();
+                    let next_indent = Self::line_indent(lines[j]);
+                    if next_trimmed.is_empty() {
+                        break;
+                    }
+                    if next_indent > 4 && !next_trimmed.starts_with("- name:") {
+                        end = j;
+                    } else {
+                        break;
+                    }
+                }
+                insert_pos = Some(end + 1);
+            }
+        }
+
+        if !file_section_found {
+            // Add file: section before tree: or at end of project
+            let mut tree_pos = None;
+            current_project = -1;
+
+            for (i, line) in lines.iter().enumerate() {
+                let trimmed = line.trim();
+                if trimmed.starts_with("- name:") && Self::line_indent(line) == 0 {
+                    current_project += 1;
+                }
+                if current_project as usize != project_index {
+                    continue;
+                }
+                if trimmed == "tree:" && Self::line_indent(line) == 2 {
+                    tree_pos = Some(i);
+                    break;
+                }
+            }
+
+            if let Some(tp) = tree_pos {
+                result_lines.insert(tp, format!("    - name: {}", file_name));
+                result_lines.insert(tp, "  file:".to_string());
+            } else {
+                let project_end = Self::find_project_end(&lines, project_index);
+                result_lines.insert(project_end, format!("    - name: {}", file_name));
+                result_lines.insert(project_end, "  file:".to_string());
+            }
+        } else if let Some(pos) = insert_pos {
+            let new_line = format!("    - name: {}", file_name);
+            result_lines.insert(pos, new_line);
+        }
+
+        Ok(result_lines.join("\n"))
+    }
+
+    /// Find the end line index of a project (exclusive - line after last content)
+    fn find_project_end(lines: &[&str], project_index: usize) -> usize {
+        let mut current_project: i32 = -1;
+        let mut project_start = 0;
+
+        for (i, line) in lines.iter().enumerate() {
+            let trimmed = line.trim();
+            if trimmed.starts_with("- name:") && Self::line_indent(line) == 0 {
+                current_project += 1;
+                if current_project as usize == project_index {
+                    project_start = i;
+                }
+                if current_project as usize > project_index {
+                    return i;
+                }
+            }
+        }
+
+        // Last project - return end of file
+        let _ = project_start;
+        lines.len()
+    }
+}
+
+/// Represents a child entry to be added (file or subdirectory with its own children)
+#[derive(Debug, Clone)]
+pub struct AddChild {
+    pub name: String,
+    pub is_directory: bool,
+    pub children: Vec<AddChild>,
+}
+
+impl AddChild {
+    /// Build a tree of AddChild from a list of relative file paths under a base directory
+    pub fn from_paths(paths: &[std::path::PathBuf], base: &std::path::Path) -> Vec<AddChild> {
+        let mut tree: BTreeMap<String, Vec<std::path::PathBuf>> = BTreeMap::new();
+        let mut files: Vec<String> = Vec::new();
+
+        for path in paths {
+            let relative = match path.strip_prefix(base) {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+
+            let components: Vec<&std::ffi::OsStr> = relative.components()
+                .filter_map(|c| match c {
+                    std::path::Component::Normal(n) => Some(n),
+                    _ => None,
+                })
+                .collect();
+
+            if components.is_empty() {
+                continue;
+            }
+
+            if components.len() == 1 {
+                let name = components[0].to_string_lossy().to_string();
+                if path.is_dir() {
+                    tree.entry(name).or_default();
+                } else {
+                    files.push(name);
+                }
+            } else {
+                let dir_name = components[0].to_string_lossy().to_string();
+                tree.entry(dir_name.clone()).or_default();
+                tree.get_mut(&dir_name).unwrap().push(
+                    components[1..].iter().collect::<std::path::PathBuf>()
+                );
+            }
+        }
+
+        let mut result = Vec::new();
+
+        // Add directories first
+        for (dir_name, sub_paths) in &tree {
+            let sub_base = Path::new("");
+            let children = Self::from_paths(sub_paths, sub_base);
+            result.push(AddChild {
+                name: dir_name.clone(),
+                is_directory: true,
+                children,
+            });
+        }
+
+        // Add files
+        for file_name in &files {
+            result.push(AddChild {
+                name: file_name.clone(),
+                is_directory: false,
+                children: vec![],
+            });
+        }
+
+        result
+    }
 }
 
 #[cfg(test)]
@@ -656,5 +1311,194 @@ mod tests {
         assert!(!result.contains("integration"));
         assert!(result.contains("- name: src"));
         assert!(result.contains("- name: main"));
+    }
+
+    // ========== Add Entry Tests ==========
+
+    #[test]
+    fn test_add_file_to_existing_module() {
+        let yaml = "\
+- name: app
+  root: true
+  lang: rust
+  tree:
+    - name: src
+      file:
+        - name: main
+      tree:
+        - name: domain
+          file:
+            - name: model
+";
+
+        let result = YamlModifier::add_entry(
+            yaml,
+            0,
+            &["src".to_string(), "domain".to_string(), "repository.rs".to_string()],
+            false,
+            "rust",
+            &[],
+        ).unwrap();
+
+        assert!(result.contains("- name: repository"));
+        assert!(result.contains("- name: model"));
+    }
+
+    #[test]
+    fn test_add_file_creates_file_section() {
+        let yaml = "\
+- name: app
+  root: true
+  lang: rust
+  tree:
+    - name: src
+      tree:
+        - name: domain
+";
+
+        let result = YamlModifier::add_entry(
+            yaml,
+            0,
+            &["src".to_string(), "domain".to_string(), "model.rs".to_string()],
+            false,
+            "rust",
+            &[],
+        ).unwrap();
+
+        assert!(result.contains("file:"));
+        assert!(result.contains("- name: model"));
+    }
+
+    #[test]
+    fn test_add_new_module() {
+        let yaml = "\
+- name: app
+  root: true
+  lang: rust
+  tree:
+    - name: src
+      file:
+        - name: main
+";
+
+        let result = YamlModifier::add_entry(
+            yaml,
+            0,
+            &["src".to_string(), "api".to_string()],
+            true,
+            "rust",
+            &[],
+        ).unwrap();
+
+        assert!(result.contains("- name: api"));
+        assert!(result.contains("- name: src"));
+    }
+
+    #[test]
+    fn test_add_directory_with_children() {
+        let yaml = "\
+- name: app
+  root: true
+  lang: rust
+  tree:
+    - name: src
+      file:
+        - name: main
+";
+
+        let children = vec![
+            AddChild {
+                name: "handler.rs".to_string(),
+                is_directory: false,
+                children: vec![],
+            },
+            AddChild {
+                name: "router.rs".to_string(),
+                is_directory: false,
+                children: vec![],
+            },
+        ];
+
+        let result = YamlModifier::add_entry(
+            yaml,
+            0,
+            &["src".to_string(), "api".to_string()],
+            true,
+            "rust",
+            &children,
+        ).unwrap();
+
+        assert!(result.contains("- name: api"));
+        assert!(result.contains("- name: handler"));
+        assert!(result.contains("- name: router"));
+    }
+
+    #[test]
+    fn test_add_project_level_file() {
+        let yaml = "\
+- name: docs
+  root: true
+  lang: any
+  tree:
+    - name: src
+";
+
+        let result = YamlModifier::add_entry(
+            yaml,
+            0,
+            &["README.md".to_string()],
+            false,
+            "any",
+            &[],
+        ).unwrap();
+
+        assert!(result.contains("file:"));
+        assert!(result.contains("- name: README.md"));
+    }
+
+    #[test]
+    fn test_add_duplicate_file_is_noop() {
+        let yaml = "\
+- name: app
+  root: true
+  lang: rust
+  tree:
+    - name: src
+      file:
+        - name: main
+";
+
+        let result = YamlModifier::add_entry(
+            yaml,
+            0,
+            &["src".to_string(), "main.rs".to_string()],
+            false,
+            "rust",
+            &[],
+        ).unwrap();
+
+        // Should be unchanged
+        assert_eq!(result, yaml);
+    }
+
+    #[test]
+    fn test_add_top_level_module_creates_tree() {
+        let yaml = "\
+- name: app
+  root: true
+  lang: rust
+";
+
+        let result = YamlModifier::add_entry(
+            yaml,
+            0,
+            &["src".to_string()],
+            true,
+            "rust",
+            &[],
+        ).unwrap();
+
+        assert!(result.contains("tree:"));
+        assert!(result.contains("- name: src"));
     }
 }

--- a/src/shared/utils/diff.rs
+++ b/src/shared/utils/diff.rs
@@ -1,0 +1,43 @@
+const RED: &str = "\x1b[31m";
+const GREEN: &str = "\x1b[32m";
+const RESET: &str = "\x1b[0m";
+
+pub fn show_diff(old: &str, new: &str) {
+    let old_lines: Vec<&str> = old.lines().collect();
+    let new_lines: Vec<&str> = new.lines().collect();
+
+    let mut old_idx = 0;
+    let mut new_idx = 0;
+
+    while old_idx < old_lines.len() || new_idx < new_lines.len() {
+        if old_idx < old_lines.len() && new_idx < new_lines.len() {
+            if old_lines[old_idx] == new_lines[new_idx] {
+                println!("  {}", old_lines[old_idx]);
+                old_idx += 1;
+                new_idx += 1;
+            } else {
+                let mut found = false;
+                for ahead in 0..old_lines.len() - old_idx {
+                    if new_idx < new_lines.len() && old_lines[old_idx + ahead] == new_lines[new_idx] {
+                        for k in 0..ahead {
+                            println!("{}- {}{}", RED, old_lines[old_idx + k], RESET);
+                        }
+                        old_idx += ahead;
+                        found = true;
+                        break;
+                    }
+                }
+                if !found {
+                    println!("{}- {}{}", RED, old_lines[old_idx], RESET);
+                    old_idx += 1;
+                }
+            }
+        } else if old_idx < old_lines.len() {
+            println!("{}- {}{}", RED, old_lines[old_idx], RESET);
+            old_idx += 1;
+        } else {
+            println!("{}+ {}{}", GREEN, new_lines[new_idx], RESET);
+            new_idx += 1;
+        }
+    }
+}

--- a/src/shared/utils/mod.rs
+++ b/src/shared/utils/mod.rs
@@ -1,4 +1,5 @@
 // start auto exported by moli.
 pub mod content_updater;
+pub mod diff;
 // end auto exported by moli.
 


### PR DESCRIPTION
未管理のファイル・ディレクトリをインタラクティブに選択してmoli.ymlに追加するloadサブコマンドを実装。
- ファイルシステムスキャンによる未管理エントリの検出
- プロジェクトルートディレクトリ選択時の子要素直接追加に対応
- 変更が発生しないエントリの選択肢からの事前除外