### PR TITLE
v2.4.1 lang: anyでREADME.mdを自動生成しないよう修正

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "moli"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moli"
-version = "2.4.0"
+version = "2.4.1"
 edition = "2021"
 
 [[bin]]

--- a/src/code_generation/language/any/file_handler.rs
+++ b/src/code_generation/language/any/file_handler.rs
@@ -42,13 +42,6 @@ impl AnyFileHandler {
             Self::generate_module(project_path, module)?;
         }
 
-        // Create empty README.md if it doesn't exist
-        let readme_path = project_path.join("README.md");
-        if !readme_path.exists() {
-            fs::write(&readme_path, "")
-                .with_context(|| format!("Failed to create README.md: {}", readme_path.display()))?;
-        }
-
         Ok(())
     }
 


### PR DESCRIPTION
## 変更内容

- `lang: any` のプロジェクトで `moli up` 実行時に `README.md` が自動生成される挙動を削除
- `moli.yml` に明示的に記載された場合のみファイルが生成されるようになった

## バージョン

`2.4.0` → `2.4.1`